### PR TITLE
use linked-hash-map

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ version = "0.1.0"
 
 [dependencies]
 anyhow = "1.0"
-indexmap = "1.9.1"
 itertools = "0.10.3"
+linked-hash-map = "0.5.6"
 thiserror = "1.0"
 
 atty = "0.2"

--- a/src/ast/edit.rs
+++ b/src/ast/edit.rs
@@ -106,4 +106,20 @@ mod tests {
 
         assert_eq!(json, Value::parse(r#"{"key": [1, 2, 3, 4], "foo": {"bar": "baz"}}"#).unwrap());
     }
+
+    #[test]
+    fn test_insertion_order() {
+        let raw = r#"{"foo": "hoge", "bar": "fuga", "baz": "piyo"}"#;
+        let mut json = Value::parse(raw).unwrap();
+
+        json.update_with(|val| {
+            let mut cloned = val.object().clone();
+            cloned.remove("bar");
+            cloned.insert("one".to_string(), Value::from(1));
+            cloned.insert("baz".to_string(), Value::from("piyo"));
+            Value::from(cloned)
+        });
+
+        assert_eq!(json.to_string(), r#"{"foo":"hoge","one":1,"baz":"piyo"}"#)
+    }
 }

--- a/src/ast/into.rs
+++ b/src/ast/into.rs
@@ -1,26 +1,26 @@
 use super::Value;
-use indexmap::IndexMap;
+use linked_hash_map::LinkedHashMap;
 
-/// evaluate `Value` to corresponded object such as `IndexMap`, `Vec`, `bool`, `str`, `i64`, or `f64`.
+/// evaluate `Value` to corresponded object such as `LinkedHashMap`, `Vec`, `bool`, `str`, `i64`, or `f64`.
 /// # panics
 /// call different type evaluate method cause panic.
 /// for example, if call [`Value::object`] to [`Value::Array`], it will panic.
 /// if want to get `None` instead of panic, use `get_` prefixed methods.
 impl Value {
-    pub fn get_object(&self) -> Option<&IndexMap<String, Value>> {
+    pub fn get_object(&self) -> Option<&LinkedHashMap<String, Value>> {
         match self {
             Value::Object(m) => Some(m),
             _ => None,
         }
     }
-    pub fn get_mut_object(&mut self) -> Option<&mut IndexMap<String, Value>> {
+    pub fn get_mut_object(&mut self) -> Option<&mut LinkedHashMap<String, Value>> {
         match self {
             Value::Object(m) => Some(m),
             _ => None,
         }
     }
-    pub fn object(&self) -> &IndexMap<String, Value> {
-        self.get_object().unwrap_or_else(|| panic!("only Object can convert into IndexMap, but {}", self.node_type()))
+    pub fn object(&self) -> &LinkedHashMap<String, Value> {
+        self.get_object().unwrap_or_else(|| panic!("only Object can convert into HashMap, but {}", self.node_type()))
     }
 
     pub fn get_array(&self) -> Option<&Vec<Value>> {
@@ -155,19 +155,19 @@ impl Value {
     }
 }
 
-impl From<Value> for IndexMap<String, Value> {
+impl From<Value> for LinkedHashMap<String, Value> {
     fn from(val: Value) -> Self {
         match val {
             Value::Object(m) => m,
-            _ => panic!("only Object can convert into IndexMap, but {}", val.node_type()),
+            _ => panic!("only Object can convert into HashMap, but {}", val.node_type()),
         }
     }
 }
-impl<'a> From<&'a Value> for &'a IndexMap<String, Value> {
+impl<'a> From<&'a Value> for &'a LinkedHashMap<String, Value> {
     fn from(val: &'a Value) -> Self {
         match val {
             Value::Object(m) => m,
-            _ => panic!("only Object can convert into IndexMap, but {}", val.node_type()),
+            _ => panic!("only Object can convert into HashMap, but {}", val.node_type()),
         }
     }
 }
@@ -291,8 +291,8 @@ impl Value {
     }
 }
 
-impl From<IndexMap<String, Value>> for Value {
-    fn from(m: IndexMap<String, Value>) -> Self {
+impl From<LinkedHashMap<String, Value>> for Value {
+    fn from(m: LinkedHashMap<String, Value>) -> Self {
         Value::Object(m)
     }
 }

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -6,7 +6,7 @@ pub mod into;
 pub mod io;
 pub mod visit;
 
-use indexmap::IndexMap;
+use linked_hash_map::LinkedHashMap;
 
 /// [`Value`] is ast node of json. see [Introducing JSON](https://www.json.org/json-en.html) also.
 /// # supports
@@ -56,7 +56,7 @@ use indexmap::IndexMap;
 #[derive(PartialEq, Debug, Clone)]
 pub enum Value {
     /// correspond to object of json. object can be represented by `HashMap` in rust.
-    Object(IndexMap<String, Value>),
+    Object(LinkedHashMap<String, Value>),
 
     /// correspond to array of json. array can be represented by `Vec` in rust.
     Array(Vec<Value>),

--- a/src/ast/visit.rs
+++ b/src/ast/visit.rs
@@ -5,7 +5,7 @@ pub struct DfsVisitor<'a> {
     first: Option<&'a Value>,
 }
 enum ValueIterator<'a> {
-    ObjectIterator(indexmap::map::Iter<'a, String, Value>),
+    ObjectIterator(linked_hash_map::Iter<'a, String, Value>),
     ArrayIterator(std::slice::Iter<'a, Value>),
 }
 #[derive(Debug, PartialEq)]

--- a/src/syntax/parser.rs
+++ b/src/syntax/parser.rs
@@ -10,7 +10,7 @@ use super::{
 };
 use crate::ast::Value;
 use anyhow::Context as _;
-use indexmap::IndexMap;
+use linked_hash_map::LinkedHashMap;
 
 pub struct Parser<'a> {
     pub(crate) lexer: Lexer<'a>,
@@ -52,7 +52,7 @@ impl<'a> Parser<'a> {
     /// parse `object` of json. the following ebnf is not precise.<br>
     /// `object` := "{" { `string` ":" `value` \[ "," \] }  "}"
     pub fn parse_object(&mut self) -> anyhow::Result<Value> {
-        let mut object = IndexMap::new();
+        let mut object = LinkedHashMap::new();
         let (_, _left_brace) = self.lexer.lex_1_char::<_, SkipWs<true>>(MainToken::LeftBrace)?;
         while !self.lexer.is_next::<_, SkipWs<true>>(MainToken::RightBrace) {
             if self.lexer.is_next::<_, SkipWs<true>>(MainToken::Quotation) {
@@ -304,7 +304,7 @@ mod tests {
         let mut parser = Parser::new(&empty);
         let object = parser.parse_object();
         if let Value::Object(m) = object.unwrap() {
-            assert_eq!(m, IndexMap::new());
+            assert_eq!(m, LinkedHashMap::new());
         } else {
             unreachable!("\"{{}}\" must be parsed as empty object");
         }


### PR DESCRIPTION
# linked-hash-map
linked-hash-map will keep insertion order.
https://crates.io/crates/linked-hash-map

# compare to indexmap
insertion order of indexmap was broken when its entry removed. but linked-hash-map will keep order such situation.